### PR TITLE
Ticket void fix

### DIFF
--- a/src/app/pages/tickest/components/options-ticket/options-ticket.component.html
+++ b/src/app/pages/tickest/components/options-ticket/options-ticket.component.html
@@ -12,7 +12,7 @@
     Discounts
     <ion-icon slot="end" name="cash-outline"></ion-icon>
   </ion-item>
-  <ion-item href="{{downloadString}}" target="_blank">
+  <ion-item *ngIf="downloadString" href="{{downloadString}}" target="_blank">
     Download
     <ion-icon slot="end" name="download-outline"></ion-icon>
   </ion-item>

--- a/src/app/pages/tickest/components/options-ticket/options-ticket.component.ts
+++ b/src/app/pages/tickest/components/options-ticket/options-ticket.component.ts
@@ -36,9 +36,11 @@ export class OptionsTicketComponent implements OnInit {
     this.userPermissions = this.session.getPermissions();
     this.userName = this.session.getUser().name;
 
-    getDownloadURL(ref(this.storage, this.ticket.pdfLink)).then(val => {
-      this.downloadString = val;
-    });
+    if(this.ticket.pdfLink) {
+      getDownloadURL(ref(this.storage, this.ticket.pdfLink)).then(val => {
+        this.downloadString = val;
+      });
+    }
   }
   public openDialog = async () => {
     this.closePanel();


### PR DESCRIPTION
Updated logic to get user permissions before getting pdf download url for tickets. Also prevented getting download URL if pdf link doesn't exist in ticket document.