### PR TITLE
Hotfix/contract info and printables

### DIFF
--- a/src/app/modules/contract-printables/contract-printables.module.ts
+++ b/src/app/modules/contract-printables/contract-printables.module.ts
@@ -9,7 +9,7 @@ import { PurchaseUnfixedPriceComponent } from './purchase-unfixed-price/purchase
 import { PurchaseToDepositComponent } from './purchase-to-deposit/purchase-to-deposit.component';
 import { PurchaseFixedPriceComponent } from './purchase-fixed-price/purchase-fixed-price.component';
 import { PurchaseContractComponent } from './purchase-contract/purchase-contract.component';
-import { ContractIdPipe, CurrencySplitPipe, ExchangeRateFieldPipe, NumberNameSpanishPipe, SelectFieldDisplayPipe } from './printable-contract-utilities.service';
+import { ContractIdPipe, CurrencySplitPipe, ExchangeRateFieldPipe, FlatPricePipe, MaskValuePipe, MaskZerosPipe, NumberNameSpanishPipe, SelectFieldDisplayPipe } from './printable-contract-utilities.service';
 import { CoreModule } from '@core/core.module';
 import { SharedModule } from '@shared/shared.module';
 import { ContractDialogComponent } from './contract-dialog/contract-dialog.component';
@@ -33,7 +33,10 @@ import { ContractDialogComponent } from './contract-dialog/contract-dialog.compo
     CurrencySplitPipe,
     FocusedFieldDirective,
     ContractIdPipe,
-    ContractDialogComponent
+    ContractDialogComponent,
+    FlatPricePipe,
+    MaskZerosPipe,
+    MaskValuePipe
   ],
   exports: [
     PrintableContractComponent

--- a/src/app/modules/contract-printables/printable-contract-utilities.service.ts
+++ b/src/app/modules/contract-printables/printable-contract-utilities.service.ts
@@ -1,7 +1,8 @@
+import { DatePipe } from '@angular/common';
 import { Injectable, Pipe, PipeTransform } from '@angular/core';
 import { Firestore } from '@angular/fire/firestore';
 import { SessionInfo } from '@core/services/session-info/session-info.service';
-import { Contract } from '@shared/classes/contract';
+import { Contract, MONTH_CODES, PRODUCT_CODES } from '@shared/classes/contract';
 import { ContractSettings, FormField, SelectOption } from '@shared/classes/contract-settings';
 import { Mass, units } from '@shared/classes/mass';
 
@@ -221,3 +222,51 @@ const Millones = (num: number) => {
   if (strMillones == '') return strMiles
   return strMillones + ' ' + strMiles
 } //Millones()
+
+@Pipe({
+  name: 'flatPrice'
+})
+export class FlatPricePipe implements PipeTransform {
+
+  readonly MONTH_CODES = MONTH_CODES;
+  readonly PRODUCT_CODES = PRODUCT_CODES;
+
+  constructor(
+    private datepipe: DatePipe
+  ) {}
+  
+  transform(futuresMonth: Date, base: number, productName: string): string {
+    if (!futuresMonth || !base || !productName) return "";
+    
+    const productCode = PRODUCT_CODES[productName.toLocaleLowerCase()];
+    if (!productCode) return "";
+    
+    let result: string = Math.round(base * 100).toString();
+    result += productCode;
+    result += MONTH_CODES[this.datepipe.transform(futuresMonth, "MMM").toLocaleUpperCase()];
+    result +=  this.datepipe.transform(futuresMonth, "YY");
+
+    return result;
+  }
+
+}
+
+@Pipe({
+  name: "maskZeros"
+})
+export class MaskZerosPipe implements PipeTransform {
+  transform(value: string, format?: "NA"): string {
+    const maskedValue = format === "NA" ? "N/A" : "--";
+    return (!value || !(+(value?.replace(/,/g, "")))) ? maskedValue : value;
+  }
+}
+
+@Pipe({
+  name: "maskValue"
+})
+export class MaskValuePipe implements PipeTransform {
+  transform(value: string, condition?: boolean, format?: "NA"): string {
+    const maskedValue = format === "NA" ? "N/A" : "--";
+    return condition ? maskedValue : value;
+  }
+}

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
@@ -38,7 +38,7 @@
         <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
         <span [printableField]="'price.amount'" *ngIf="contractForm.price?.amount > 0 else altPriceFormat">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5" | maskZeros }}&nbsp;/&nbsp;BU</span>
         <ng-template #altPriceFormat>
-          <span [printableField]="'price.amount'">{{ contractForm.futurePriceInfo.expirationMonth | flatPrice:contractForm.base:contractForm.product?.id | maskZeros }}</span>
+          <span [printableField]="'price.amount'">{{ contractForm.futurePriceInfo.expirationMonth | flatPrice:contractForm.base:contractForm.product?.id }}</span>
         </ng-template>
         <br>
         <span [printableField]="'date'">{{ contractForm.date | date:'MM/dd/YYYY' }}</span><br>

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
@@ -41,7 +41,7 @@
           <span *ngIf="contractForm.price.amount">&nbsp;/&nbsp;BU</span>
         </span><br>
         <ng-template #altPriceFormat>
-          <span [printableField]="'price.amount'" *ngIf="contractForm.base && contractForm.futurePriceInfo.expirationMonth">{{ (contractForm.base * 100 | number:'0.0') + 'C' + MONTH_CODES[contractForm.futurePriceInfo.expirationMonth | date:"MMM" | uppercase] + (contractForm.futurePriceInfo.expirationMonth | date:"YY") }}</span>
+          <span [printableField]="'price.amount'">{{ (contractForm.base * 100 | number:'0.0') + 'C' + MONTH_CODES[contractForm.futurePriceInfo.expirationMonth | date:"MMM" | uppercase] + (contractForm.futurePriceInfo.expirationMonth | date:"YY") }}</span>
         </ng-template>
         <span [printableField]="'date'">{{ contractForm.date | date:'MM/dd/YYYY' }}</span><br>
         <br>

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
@@ -189,8 +189,14 @@
     
     <p>The Buyer is purchasing the following Goods from the Seller: <span [printableField]="'product'">{{ contractForm.product?.id }}</span>	</p>
     
-    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ !contractForm.isOpen || contractForm.status == 'closed'? ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits) * 
-      (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits) | number:'1.2-2') : '-' }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
+    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ 
+      ((!contractForm.isOpen || contractForm.status == 'closed') && 
+        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
+      ) ? 
+        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
+      : 
+        '--' 
+      }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
     
     <p><b>PAYMENT:</b> The Purchase Price shall be paid only in the following payment methods: <br>
     •	<br>

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
@@ -34,12 +34,15 @@
       </div>
       <div class='column-size-3' *ngIf="contractForm.date">
         <b><span [printableField]="'id'">{{ contractForm.id || 0 }}</span>-{{ contractForm.date.getFullYear() % 100 }}</b><br>
-        <!-- {{ contractForm.price | getPricePerUnit:"bu":product }} -->
         <span [printableField]="'base'">{{ contractForm.base | number:"0.5-5" }}</span><br>
         <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5-5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
-        <span [printableField]="'price.amount'">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5-5" }}</span>
-        <span *ngIf="contractForm.price.amount">&nbsp;/&nbsp;BU</span>
-        <br>
+        <span *ngIf="contractForm.price?.amount > 0 else altPriceFormat">
+          <span [printableField]="'price.amount'">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5-5" }}</span>
+          <span *ngIf="contractForm.price.amount">&nbsp;/&nbsp;BU</span>
+        </span><br>
+        <ng-template #altPriceFormat>
+          <span [printableField]="'price.amount'" *ngIf="contractForm.base && contractForm.futurePriceInfo.expirationMonth">{{ (contractForm.base * 100 | number:'0.0') + 'C' + MONTH_CODES[contractForm.futurePriceInfo.expirationMonth | date:"MMM" | uppercase] + (contractForm.futurePriceInfo.expirationMonth | date:"YY") }}</span>
+        </ng-template>
         <span [printableField]="'date'">{{ contractForm.date | date:'MM/dd/YYYY' }}</span><br>
         <br>
         <br>

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
@@ -118,8 +118,18 @@
           </ng-container>
         </div>
         <div class='column-size-2 text-align-right' [printableField]="'price.amount'">
-          ${{ contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' }}<br>
-          ${{ contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' }}
+          $&nbsp;{{ ((contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
+            ? 
+            '--' 
+            : 
+            contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
+          }}<br>
+          $&nbsp;{{ ((contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
+            ? 
+            '--' 
+            : 
+            contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
+          }}
         </div>
         <div class='column-size-2 text-align-right'>
           &nbsp;/&nbsp;CWT<br>
@@ -144,8 +154,14 @@
       <div class='column-size-2'>
         <div id='total'>
           <span><b>$</b></span>
-          <span><b>{{ !contractForm.isOpen || contractForm.status == 'closed'? ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * 
-            (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') : '-' }}</b></span>
+          <span><b>{{ 
+            ((!contractForm.isOpen || contractForm.status == 'closed') && 
+              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
+            ) ? 
+              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
+            : 
+              '--' 
+          }}</b></span>
         </div>
       </div>
     </div>

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.html
@@ -34,15 +34,13 @@
       </div>
       <div class='column-size-3' *ngIf="contractForm.date">
         <b><span [printableField]="'id'">{{ contractForm.id || 0 }}</span>-{{ contractForm.date.getFullYear() % 100 }}</b><br>
-        <span [printableField]="'base'">{{ contractForm.base | number:"0.5-5" }}</span><br>
-        <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5-5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
-        <span *ngIf="contractForm.price?.amount > 0 else altPriceFormat">
-          <span [printableField]="'price.amount'">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5-5" }}</span>
-          <span *ngIf="contractForm.price.amount">&nbsp;/&nbsp;BU</span>
-        </span><br>
+        <span [printableField]="'base'">{{ contractForm.base | number:"0.5" }}</span><br>
+        <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
+        <span [printableField]="'price.amount'" *ngIf="contractForm.price?.amount > 0 else altPriceFormat">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5" | maskZeros }}&nbsp;/&nbsp;BU</span>
         <ng-template #altPriceFormat>
-          <span [printableField]="'price.amount'">{{ (contractForm.base * 100 | number:'0.0') + 'C' + MONTH_CODES[contractForm.futurePriceInfo.expirationMonth | date:"MMM" | uppercase] + (contractForm.futurePriceInfo.expirationMonth | date:"YY") }}</span>
+          <span [printableField]="'price.amount'">{{ contractForm.futurePriceInfo.expirationMonth | flatPrice:contractForm.base:contractForm.product?.id | maskZeros }}</span>
         </ng-template>
+        <br>
         <span [printableField]="'date'">{{ contractForm.date | date:'MM/dd/YYYY' }}</span><br>
         <br>
         <br>
@@ -64,9 +62,9 @@
         <span [printableField]="'product'">{{ contractForm.product?.id }}</span><br>
         <div class='grid-3'>
           <div class='column-size-2'>
-            <span class='right-justify' [printableField]="'quantity.amount'">{{ !contractForm.isOpen || contractForm.status == 'closed'? (contractForm.quantity | massInUnit:'bu':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5') : '-' }}</span>
-            <span class='right-justify' [printableField]="'quantity.amount'">{{ !contractForm.isOpen || contractForm.status == 'closed'? (contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5') : '-' }}</span>
-            <span class='right-justify' [printableField]="'quantity.amount'">{{ !contractForm.isOpen || contractForm.status == 'closed'? (contractForm.quantity | massInUnit:'mTon':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5') : '-' }}</span>
+            <span class='right-justify' [printableField]="'quantity.amount'">{{ contractForm.quantity | massInUnit:'bu':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>
+            <span class='right-justify' [printableField]="'quantity.amount'">{{ contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>
+            <span class='right-justify' [printableField]="'quantity.amount'">{{ contractForm.quantity | massInUnit:'mTon':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>
           </div>
           <div class='column-size-1'>
             <span>BUSHELS</span><br>
@@ -121,18 +119,8 @@
           </ng-container>
         </div>
         <div class='column-size-2 text-align-right' [printableField]="'price.amount'">
-          $&nbsp;{{ ((contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
-            ? 
-            '--' 
-            : 
-            contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
-          }}<br>
-          $&nbsp;{{ ((contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
-            ? 
-            '--' 
-            : 
-            contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
-          }}
+          $&nbsp;{{ contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskZeros }}<br>
+          $&nbsp;{{ contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskZeros }}
         </div>
         <div class='column-size-2 text-align-right'>
           &nbsp;/&nbsp;CWT<br>
@@ -157,14 +145,7 @@
       <div class='column-size-2'>
         <div id='total'>
           <span><b>$</b></span>
-          <span><b>{{ 
-            ((!contractForm.isOpen || contractForm.status == 'closed') && 
-              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
-            ) ? 
-              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
-            : 
-              '--' 
-          }}</b></span>
+          <span><b>{{ (contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</b></span>
         </div>
       </div>
     </div>
@@ -192,14 +173,7 @@
     
     <p>The Buyer is purchasing the following Goods from the Seller: <span [printableField]="'product'">{{ contractForm.product?.id }}</span>	</p>
     
-    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ 
-      ((!contractForm.isOpen || contractForm.status == 'closed') && 
-        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
-      ) ? 
-        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
-      : 
-        '--' 
-      }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
+    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ (contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
     
     <p><b>PAYMENT:</b> The Purchase Price shall be paid only in the following payment methods: <br>
     •	<br>

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.ts
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnInit, QueryList, SimpleChanges, ViewChildren } from '@angular/core';
-import { Contract } from '@shared/classes/contract';
+import { Contract, MONTH_CODES } from '@shared/classes/contract';
 import { PrintableContractUtilitiesService } from '../printable-contract-utilities.service';
 import { FocusedFieldDirective } from '../printable-contract.component';
 import { ContractSettings } from '@shared/classes/contract-settings';
@@ -22,6 +22,8 @@ export class PurchaseContractComponent implements OnInit, OnChanges {
   private focusedFields: FocusedFieldDirective[] = [];
 
   readonly contractType: string = 'purchase';
+
+  readonly MONTH_CODES = MONTH_CODES;
 
   @Input() company: Company;
 

--- a/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.ts
+++ b/src/app/modules/contract-printables/purchase-contract/purchase-contract.component.ts
@@ -23,8 +23,6 @@ export class PurchaseContractComponent implements OnInit, OnChanges {
 
   readonly contractType: string = 'purchase';
 
-  readonly MONTH_CODES = MONTH_CODES;
-
   @Input() company: Company;
 
   constructor(public utils: PrintableContractUtilitiesService) {}

--- a/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
+++ b/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
@@ -39,7 +39,7 @@
         <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
         <span [printableField]="'price.amount'" *ngIf="contractForm.price?.amount > 0 else altPriceFormat">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5" | maskZeros }}&nbsp;/&nbsp;BU</span>
         <ng-template #altPriceFormat>
-          <span [printableField]="'price.amount'">{{ contractForm.futurePriceInfo.expirationMonth | flatPrice:contractForm.base:contractForm.product?.id | maskZeros }}</span>
+          <span [printableField]="'price.amount'">{{ contractForm.futurePriceInfo.expirationMonth | flatPrice:contractForm.base:contractForm.product?.id }}</span>
         </ng-template>
         <br>
         <span [printableField]="'date'">{{ contractForm.date | date:'MM/dd/YYYY' }}</span><br>

--- a/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
+++ b/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
@@ -189,8 +189,14 @@
     <br>
     The Buyer is purchasing the following Goods from the Seller: {{ contractForm.product?.id }}</p>
     
-    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ !contractForm.isOpen || contractForm.status == 'closed'? ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits) * 
-      (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits) | number:'1.2-2') : '-' }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
+    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ 
+      ((!contractForm.isOpen || contractForm.status == 'closed') && 
+        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
+      ) ? 
+        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
+      : 
+        '--' 
+    }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
     
     <p><b>PAYMENT:</b> The Purchase Price shall be paid only in the following payment methods:
     <br>

--- a/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
+++ b/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
@@ -35,10 +35,12 @@
       <div class='column-size-3' *ngIf="contractForm.date">
         <b><span [printableField]="'id'">{{ contractForm.id || 0 }}</span>-{{ contractForm.date.getFullYear() % 100 }}</b><br>
         <!-- {{ contractForm.price | getPricePerUnit:"bu":product }} -->
-        <span [printableField]="'base'">{{ contractForm.base | number:"0.5-5" }}</span><br>
-        <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5-5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
-        <span [printableField]="'price.amount'">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5-5" }}</span>
-        <span *ngIf="contractForm.price.amount">&nbsp;/&nbsp;BU</span>
+        <span [printableField]="'base'">{{ contractForm.base | number:"0.5" }}</span><br>
+        <span [printableField]="'market_price'">{{ (contractForm.market_price | number:"0.5") ?? (contractForm.futurePriceInfo.expirationMonth | date:"MMM YYYY" | uppercase) }}</span><br>
+        <span [printableField]="'price.amount'" *ngIf="contractForm.price?.amount > 0 else altPriceFormat">{{ contractForm.price | pricePerUnit:"bu":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits | number:"0.5" | maskZeros }}&nbsp;/&nbsp;BU</span>
+        <ng-template #altPriceFormat>
+          <span [printableField]="'price.amount'">{{ contractForm.futurePriceInfo.expirationMonth | flatPrice:contractForm.base:contractForm.product?.id | maskZeros }}</span>
+        </ng-template>
         <br>
         <span [printableField]="'date'">{{ contractForm.date | date:'MM/dd/YYYY' }}</span><br>
         <br>
@@ -61,9 +63,9 @@
         <span [printableField]="'product'">{{ contractForm.product?.id }}</span><br>
         <div class='grid-3'>
           <div class='column-size-2'>
-            <span class='right-justify' [printableField]="'quantity.amount'">{{ !contractForm.isOpen || contractForm.status == 'closed'? (contractForm.quantity | massInUnit:'bu':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5') : '-' }}</span>
-            <span class='right-justify' [printableField]="'quantity.amount'">{{ !contractForm.isOpen || contractForm.status == 'closed'? (contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5') : '-' }}</span>
-            <span class='right-justify' [printableField]="'quantity.amount'">{{ !contractForm.isOpen || contractForm.status == 'closed'? (contractForm.quantity | massInUnit:'mTon':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5') : '-' }}</span>
+            <span class='right-justify' [printableField]="'quantity.amount'">{{ contractForm.quantity | massInUnit:'bu':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>
+            <span class='right-justify' [printableField]="'quantity.amount'">{{ contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>
+            <span class='right-justify' [printableField]="'quantity.amount'">{{ contractForm.quantity | massInUnit:'mTon':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>
           </div>
           <div class='column-size-1'>
             <span>BUSHELS</span><br>
@@ -118,18 +120,8 @@
           </ng-container>
         </div>
         <div class='column-size-2 text-align-right' [printableField]="'price.amount'">
-          $&nbsp;{{ ((contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
-            ? 
-            '--' 
-            : 
-            contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
-          }}<br>
-          $&nbsp;{{ ((contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
-            ? 
-            '--' 
-            : 
-            contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
-          }}
+          $&nbsp;{{ contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskZeros }}<br>
+          $&nbsp;{{ contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5' | maskZeros }}
         </div>
         <div class='column-size-2 text-align-right'>
           &nbsp;/&nbsp;CWT<br>
@@ -154,14 +146,7 @@
       <div class='column-size-2'>
         <div id='total'>
           <span><b>$</b></span>
-          <span><b>{{ 
-            ((!contractForm.isOpen || contractForm.status == 'closed') && 
-              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
-            ) ? 
-              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
-            : 
-              '--' 
-          }}</b></span>
+          <span><b>{{ (contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</b></span>
         </div>
       </div>
     </div>
@@ -189,14 +174,7 @@
     <br>
     The Buyer is purchasing the following Goods from the Seller: {{ contractForm.product?.id }}</p>
     
-    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ 
-      ((!contractForm.isOpen || contractForm.status == 'closed') && 
-        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
-      ) ? 
-        ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
-      : 
-        '--' 
-    }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
+    <p><b>PRICE:</b> Buyer agrees to pay the purchase price (the "Purchase Price") of <span class="fill-line">{{ (contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2' | maskValue:(contractForm.isOpen && contractForm.status !== 'closed') | maskZeros }}</span>$ to the Seller as consideration for the sale of the Goods mentioned above. The Purchase Price is exclusive of any pertinent taxes.</p>
     
     <p><b>PAYMENT:</b> The Purchase Price shall be paid only in the following payment methods:
     <br>

--- a/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
+++ b/src/app/modules/contract-printables/sales-contract/sales-contract.component.html
@@ -118,8 +118,18 @@
           </ng-container>
         </div>
         <div class='column-size-2 text-align-right' [printableField]="'price.amount'">
-          ${{ contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' }}<br>
-          ${{ contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' }}
+          $&nbsp;{{ ((contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
+            ? 
+            '--' 
+            : 
+            contractForm.price | pricePerUnit:"CWT":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
+          }}<br>
+          $&nbsp;{{ ((contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) ?? 0) <= 0 
+            ? 
+            '--' 
+            : 
+            contractForm.price | pricePerUnit:"mTon":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product | number:'0.5-5' 
+          }}
         </div>
         <div class='column-size-2 text-align-right'>
           &nbsp;/&nbsp;CWT<br>
@@ -144,8 +154,14 @@
       <div class='column-size-2'>
         <div id='total'>
           <span><b>$</b></span>
-          <span><b>{{ !contractForm.isOpen || contractForm.status == 'closed'? ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * 
-            (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') : '-' }}</b></span>
+          <span><b>{{ 
+            ((!contractForm.isOpen || contractForm.status == 'closed') && 
+              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) > 0) 
+            ) ? 
+              ((contractForm.quantity | massInUnit:'lbs':contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) * (contractForm.price | pricePerUnit:"lbs":contractForm.quantity:contractForm.price.amount:contractForm.price.unit:contractForm.quantity.amount:contractForm.quantity.defaultUnits:contractForm.product) | number:'1.2-2') 
+            : 
+              '--' 
+          }}</b></span>
         </div>
       </div>
     </div>

--- a/src/app/pages/contracts/components/close-contract-fields-dialog/close-contract-fields-dialog.component.html
+++ b/src/app/pages/contracts/components/close-contract-fields-dialog/close-contract-fields-dialog.component.html
@@ -41,7 +41,6 @@
 					<span matPrefix>$ &nbsp;</span>
 					<input
 						matInput
-						required
 						appPositive
 						[(ngModel)]="data.price"
 						#price="ngModel"
@@ -68,19 +67,32 @@
 					</mat-select>
 				</mat-form-field>
 			</mat-grid-tile>
-			<mat-grid-tile colspan="6">
+			<mat-grid-tile colspan="3">
 				<mat-form-field appearance="fill">
-					<mat-label>{{ t('Market Price') }}</mat-label>
+					<mat-label>{{ t('Future Price') }}</mat-label>
 					<span matPrefix>$ &nbsp;</span>
 					<input
 						matInput
-						required
 						[(ngModel)]="data.marketPrice"
 						#marketPrice="ngModel"
 						name="marketPrice"
 						type="number"
 					>
-					<mat-error>{{ t('Market Price is required') }}</mat-error>
+					<mat-error>{{ t('Future Price is required') }}</mat-error>
+				</mat-form-field>
+			</mat-grid-tile>
+			<mat-grid-tile colspan="3">
+				<mat-form-field appearance="fill">
+					<mat-label>{{ t('Base Price') }}</mat-label>
+					<span matPrefix>$ &nbsp;</span>
+					<input
+						matInput
+						[(ngModel)]="data.basePrice"
+						#basePrice="ngModel"
+						name="basePrice"
+						type="number"
+					>
+					<mat-error>{{ t('Base Price is required') }}</mat-error>
 				</mat-form-field>
 			</mat-grid-tile>
 		</mat-grid-list>

--- a/src/app/pages/contracts/components/close-contract-fields-dialog/close-contract-fields-dialog.component.ts
+++ b/src/app/pages/contracts/components/close-contract-fields-dialog/close-contract-fields-dialog.component.ts
@@ -18,7 +18,7 @@ export class CloseContractFieldsDialogComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.snack.openTranslated("Required fields must be filled before closing.", 'error');
+    this.snack.openTranslated("Required fields must be filled before closing.");
   }
 
   public confirm(): void {

--- a/src/app/pages/contracts/components/contract-modal-options/contract-modal-options.component.ts
+++ b/src/app/pages/contracts/components/contract-modal-options/contract-modal-options.component.ts
@@ -124,7 +124,8 @@ export class ContractModalOptionsComponent implements OnInit {
       price: this.contract.price.amount,
       priceUnit: this.contract.price.unit,
       quantity: this.contract.quantity.amount,
-      quantityUnits: this.contract.quantity.defaultUnits
+      quantityUnits: this.contract.quantity.defaultUnits,
+      basePrice: this.contract.base
     };
 
     if(this.contract.isOpen && isClosing) {
@@ -145,7 +146,8 @@ export class ContractModalOptionsComponent implements OnInit {
       price: newFieldData?.price ?? requiredFieldData.price,
       priceUnit: newFieldData?.priceUnit ?? requiredFieldData.priceUnit,
       quantity: newFieldData?.quantity ?? requiredFieldData.quantity,
-      quantityUnits: newFieldData?.quantityUnits ?? requiredFieldData.quantityUnits
+      quantityUnits: newFieldData?.quantityUnits ?? requiredFieldData.quantityUnits,
+      base: newFieldData?.basePrice ?? requiredFieldData.basePrice
     })
     .then(() => {
       this.snack.openTranslated("Contract updated", "success");
@@ -154,6 +156,7 @@ export class ContractModalOptionsComponent implements OnInit {
       this.contract.price.unit = requiredFieldData.priceUnit;
       this.contract.quantity.amount = requiredFieldData.quantity;
       this.contract.quantity.defaultUnits = requiredFieldData.quantityUnits;
+      this.contract.base = requiredFieldData.basePrice;
     })
     .catch(error => {
       console.error(error);

--- a/src/app/pages/contracts/contracts.page.html
+++ b/src/app/pages/contracts/contracts.page.html
@@ -13,17 +13,13 @@
                 <mat-select (selectionChange)="segmentChanged($event)" value="active,closed,pending,canceled,paid">
                     <mat-option value="active,closed,pending,canceled,paid">{{t('all') | titlecase}}</mat-option>
                     <mat-divider></mat-divider>
-                    <!-- <mat-optgroup label="----------------------------------------"> -->
-                        <mat-option value="active">{{t('active') | titlecase}}</mat-option>
-                        <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
-                        <mat-option value="closed">{{t('closed') | titlecase}}</mat-option>
-                        <mat-option value="paid">{{t('paid') | titlecase}}</mat-option>                        
-                    <!-- </mat-optgroup> -->
-                    <!-- <mat-optgroup label="----------------------------------------"> -->
-                        <mat-divider></mat-divider>
-                        <mat-option value="active,pending">{{ t("Active & Pending") }}</mat-option>
-                        <mat-option value="closed,paid">{{ t("Closed & Paid") }}</mat-option>
-                    <!-- </mat-optgroup> -->
+                    <mat-option value="active">{{t('active') | titlecase}}</mat-option>
+                    <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
+                    <mat-option value="closed">{{t('closed') | titlecase}}</mat-option>
+                    <mat-option value="paid">{{t('paid') | titlecase}}</mat-option>                        
+                    <mat-divider></mat-divider>
+                    <mat-option value="active,pending">{{ t("Active & Pending") }}</mat-option>
+                    <mat-option value="closed,paid">{{ t("Closed & Paid") }}</mat-option>
                 </mat-select>
             </mat-form-field>
         </div>

--- a/src/app/pages/contracts/contracts.page.html
+++ b/src/app/pages/contracts/contracts.page.html
@@ -12,7 +12,6 @@
                 <mat-label>{{t('Status')}}</mat-label>
                 <mat-select (selectionChange)="segmentChanged($event)" value="active,closed,pending,canceled,paid">
                     <mat-option value="active,closed,pending,canceled,paid">{{t('all') | titlecase}}</mat-option>
-                    <mat-divider></mat-divider>
                     <mat-option value="active">{{t('active') | titlecase}}</mat-option>
                     <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
                     <mat-option value="closed">{{t('closed') | titlecase}}</mat-option>

--- a/src/app/pages/contracts/contracts.page.html
+++ b/src/app/pages/contracts/contracts.page.html
@@ -12,10 +12,18 @@
                 <mat-label>{{t('Status')}}</mat-label>
                 <mat-select (selectionChange)="segmentChanged($event)" value="active,closed,pending,canceled,paid">
                     <mat-option value="active,closed,pending,canceled,paid">{{t('all') | titlecase}}</mat-option>
-                    <mat-option value="active">{{t('active') | titlecase}}</mat-option>
-                    <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
-                    <mat-option value="closed,paid">{{t('closed') | titlecase}}</mat-option>
-                    <mat-option value="active,pending">{{ t("Active & Pending") }}</mat-option>
+                    <mat-divider></mat-divider>
+                    <!-- <mat-optgroup label="----------------------------------------"> -->
+                        <mat-option value="active">{{t('active') | titlecase}}</mat-option>
+                        <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
+                        <mat-option value="closed">{{t('closed') | titlecase}}</mat-option>
+                        <mat-option value="paid">{{t('paid') | titlecase}}</mat-option>                        
+                    <!-- </mat-optgroup> -->
+                    <!-- <mat-optgroup label="----------------------------------------"> -->
+                        <mat-divider></mat-divider>
+                        <mat-option value="active,pending">{{ t("Active & Pending") }}</mat-option>
+                        <mat-option value="closed,paid">{{ t("Closed & Paid") }}</mat-option>
+                    <!-- </mat-optgroup> -->
                 </mat-select>
             </mat-form-field>
         </div>
@@ -177,7 +185,7 @@
                         <ion-item lines="none">
                             <ion-text class="item-text-price" color="dark"
                                 [matTooltip]="getQuantityTooltip(contract)"
-                                matTooltipClass="multiline-tooltip">zz
+                                matTooltipClass="multiline-tooltip">
                                 {{!contract.isOpen || contract.status == 'closed' || contract.status == 'paid' ? (contract.quantity | massDisplay:2:displayUnit:contract.quantity.amount:contract.quantity.defaultUnits) : '-'}}
                             </ion-text>
                         </ion-item>

--- a/src/app/pages/contracts/contracts.page.html
+++ b/src/app/pages/contracts/contracts.page.html
@@ -15,6 +15,7 @@
                     <mat-option value="active">{{t('active') | titlecase}}</mat-option>
                     <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
                     <mat-option value="closed,paid">{{t('closed') | titlecase}}</mat-option>
+                    <mat-option value="active,pending">{{ t("Active & Pending") }}</mat-option>
                 </mat-select>
             </mat-form-field>
         </div>

--- a/src/app/pages/contracts/contracts.page.html
+++ b/src/app/pages/contracts/contracts.page.html
@@ -176,7 +176,7 @@
                         <ion-item lines="none">
                             <ion-text class="item-text-price" color="dark"
                                 [matTooltip]="getQuantityTooltip(contract)"
-                                matTooltipClass="multiline-tooltip">
+                                matTooltipClass="multiline-tooltip">zz
                                 {{!contract.isOpen || contract.status == 'closed' || contract.status == 'paid' ? (contract.quantity | massDisplay:2:displayUnit:contract.quantity.amount:contract.quantity.defaultUnits) : '-'}}
                             </ion-text>
                         </ion-item>

--- a/src/app/pages/contracts/contracts.page.html
+++ b/src/app/pages/contracts/contracts.page.html
@@ -16,7 +16,7 @@
                     <mat-option value="active">{{t('active') | titlecase}}</mat-option>
                     <mat-option value="pending">{{t('pending') | titlecase}}</mat-option>
                     <mat-option value="closed">{{t('closed') | titlecase}}</mat-option>
-                    <mat-option value="paid">{{t('paid') | titlecase}}</mat-option>                        
+                    <mat-option value="paid">{{t('paid') | titlecase}}</mat-option>
                     <mat-divider></mat-divider>
                     <mat-option value="active,pending">{{ t("Active & Pending") }}</mat-option>
                     <mat-option value="closed,paid">{{ t("Closed & Paid") }}</mat-option>

--- a/src/app/pages/directory/components/edit-contact-dialog/edit-contact-dialog.component.html
+++ b/src/app/pages/directory/components/edit-contact-dialog/edit-contact-dialog.component.html
@@ -3,26 +3,22 @@
 	
 	<mat-dialog-content>
 		<form #contactForm="ngForm">
+			<mat-form-field appearance="fill">
+				<mat-label>{{t('Name')}}</mat-label>
+				<input matInput required [(ngModel)]="data.contact.name" name="name">
+				<mat-error>{{t('Name is')}} <strong>{{t('required')}}</strong></mat-error>
+			</mat-form-field>
+
+			<div class="chip-row">
+				<mat-chip-list multiple [(ngModel)]="data.contact.tags" name="tags">
+					<mat-chip value="client" #c="matChip" (click)="chipToggle(c, 'client')">{{t('Client')}}</mat-chip>
+					<mat-chip value="trucker" #tc="matChip" (click)="chipToggle(tc, 'trucker')">{{t('Trucker')}}</mat-chip>
+					<mat-chip *ngFor="let tag of data.otherTags" [value]="tag" #oc="matChip" (click)="chipToggle(oc, tag)">{{tag | titlecase}}</mat-chip>
+				</mat-chip-list>
+				<button mat-icon-button (click)="newTagDialog()"><mat-icon>add</mat-icon></button>
+			</div>
+	
 			<mat-grid-list cols="12" rowHeight="70px" gutterSize="10px">
-				<mat-grid-tile colspan="12">
-					<mat-form-field appearance="fill">
-						<mat-label>{{t('Name')}}</mat-label>
-						<input matInput required [(ngModel)]="data.contact.name" name="name">
-						<mat-error>{{t('Name is')}} <strong>{{t('required')}}</strong></mat-error>
-					</mat-form-field>
-				</mat-grid-tile>
-	
-				<mat-grid-tile colspan="12">
-					<div class="chip-row">
-						<mat-chip-list multiple [(ngModel)]="data.contact.tags" name="tags">
-							<mat-chip value="client" #c="matChip" (click)="chipToggle(c, 'client')">{{t('Client')}}</mat-chip>
-							<mat-chip value="trucker" #tc="matChip" (click)="chipToggle(tc, 'trucker')">{{t('Trucker')}}</mat-chip>
-							<mat-chip *ngFor="let tag of data.otherTags" [value]="tag" #oc="matChip" (click)="chipToggle(oc, tag)">{{tag | titlecase}}</mat-chip>
-						</mat-chip-list>
-						<button mat-icon-button (click)="newTagDialog()"><mat-icon>add</mat-icon></button>
-					</div>
-				</mat-grid-tile>
-	
 				<mat-grid-tile colspan="12">
 					<mat-form-field appearance="fill">
 						<mat-label>{{t('Street Address')}}</mat-label>

--- a/src/app/pages/directory/components/edit-contact-dialog/edit-contact-dialog.component.scss
+++ b/src/app/pages/directory/components/edit-contact-dialog/edit-contact-dialog.component.scss
@@ -43,6 +43,7 @@ div:has(> mat-grid-list) {
 	width: 100%;
 	justify-content: space-between;
 	align-items: center;
+	margin-bottom: 18px;
 }
 
 .underline {

--- a/src/app/shared/classes/contract.ts
+++ b/src/app/shared/classes/contract.ts
@@ -14,15 +14,6 @@ import { Payment } from "./payment";
 export declare type contractType = string | boolean;
 export declare type ContractStatus = 'pending' | 'active' | 'closed' | 'cancelled' | 'paid';
 
-const MONTHS_LIST = ['March', 'May', 'July', 'September', 'December'];
-export const MONTH_CODES = {
-  MAR: 'H',
-  MAY: 'K',
-  JUL: 'N',
-  SEP: 'U',
-  DEC: 'Z'
-};
-
 export class Contract extends FirebaseDocInterface {
     aflatoxin: number;
     bankInfo: BankInfo[];
@@ -786,3 +777,30 @@ export interface Exectuive {
     name: string,
     ref: DocumentReference
 }
+
+export const MONTH_CODES = {
+    JAN: 'F',
+    FEB: 'G',
+    MAR: 'H',
+    APR: 'J',
+    MAY: 'K',
+    JUN: 'M',
+    JUL: 'N',
+    AUG: 'Q',
+    SEP: 'U',
+    OCT: 'V',
+    NOV: 'X',
+    DEC: 'Z'
+};
+
+export const PRODUCT_CODES = {
+    "yellow corn": 'C',
+    "soybean": 'S',
+    "hard red winter wheat": 'KE',
+    "rough rice": 'R',
+    "sorghum": 'SOR'
+};
+
+const PRODUCT_CODES_DAILY_LAST_PRICE = {
+    "hard red winter wheat": 'KW'
+};

--- a/src/app/shared/classes/contract.ts
+++ b/src/app/shared/classes/contract.ts
@@ -14,6 +14,15 @@ import { Payment } from "./payment";
 export declare type contractType = string | boolean;
 export declare type ContractStatus = 'pending' | 'active' | 'closed' | 'cancelled' | 'paid';
 
+const MONTHS_LIST = ['March', 'May', 'July', 'September', 'December'];
+export const MONTH_CODES = {
+  MAR: 'H',
+  MAY: 'K',
+  JUL: 'N',
+  SEP: 'U',
+  DEC: 'Z'
+};
+
 export class Contract extends FirebaseDocInterface {
     aflatoxin: number;
     bankInfo: BankInfo[];

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -79,7 +79,9 @@
                 "Delivered": "Delivered",
                 "Total": "Total",
                 "Trend": "Trend"
-            }
+            },
+            "active & pending": "active & pending",
+            "Active & Pending": "Active & Pending"
         },
         "new": {
             "contract info": "Contract Info",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -80,8 +80,8 @@
                 "Total": "Total",
                 "Trend": "Trend"
             },
-            "active & pending": "active & pending",
-            "Active & Pending": "Active & Pending"
+            "Active & Pending": "Active & Pending",
+            "Closed & Paid": "Closed & Paid"
         },
         "new": {
             "contract info": "Contract Info",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -256,7 +256,9 @@
             "Quantity": "Quantity",
             "Price": "Price",
             "Future Price": "Future Price",
-            "Base Price": "Base Price"
+            "Base Price": "Base Price",
+            "Base Price is required": "Base Price is required",
+            "Future Price is required": "Future Price is required"
         }
     },
     "directory": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -252,7 +252,9 @@
             "Quantity must be positive": "Quantity must be positive",
             "Market Price is required": "Market Price is required",
             "Quantity": "Quantity",
-            "Price": "Price"
+            "Price": "Price",
+            "Future Price": "Future Price",
+            "Base Price": "Base Price"
         }
     },
     "directory": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -256,7 +256,9 @@
             "Quantity": "Cantidad",
             "Price": "Precio",
             "Future Price": "Precio Futuro",
-            "Base Price": "Precio Base"
+            "Base Price": "Precio Base",
+            "Base Price is required": "El precio base es requerido",
+            "Future Price is required": "El precio futuro es requerido"
         }
     },
     "directory": {

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -80,8 +80,8 @@
                 "Total": "Total",
                 "Trend": "Tendencia"
             },
-            "active & pending": "activo & pendiente",
-            "Active & Pending": "Activo y Pendiente"
+            "Active & Pending": "Activo y Pendiente",
+            "Closed & Paid": "Cerrado y Pagado"
         },
         "new": {
             "contract info": "Información de Contrato",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -79,7 +79,9 @@
                 "Delivered": "Entregado",
                 "Total": "Total",
                 "Trend": "Tendencia"
-            }
+            },
+            "active & pending": "activo & pendiente",
+            "Active & Pending": "Activo y Pendiente"
         },
         "new": {
             "contract info": "Información de Contrato",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -252,7 +252,9 @@
             "Quantity must be positive": "La cantidad debe ser positiva",
             "Market Price is required": "El precio de mercado es requerido",
             "Quantity": "Cantidad",
-            "Price": "Precio"
+            "Price": "Precio",
+            "Future Price": "Precio Futuro",
+            "Base Price": "Precio Base"
         }
     },
     "directory": {


### PR DESCRIPTION
- Added new flat price format. (Ex: 40CH25)
- Added pipes for displaying flat price format and to mask values based on a given condition.
- Added active & pending option when selecting what contracts to view in the table.
- Updated "Modify Price and Quantity" dialog to not require certain prices like the market price.
- Fixed the tags in the contact dialog component.
- Removed 0's from sales and purchase contract printables.